### PR TITLE
Allow latest Windows build of the MP dedicated server

### DIFF
--- a/uaseco.php
+++ b/uaseco.php
@@ -46,7 +46,7 @@
 	define('UASECO_WEBSITE',	'http://www.UASECO.org/');
 
 	// Setup required official dedicated server build, Api-Version and PHP-Version
-	define('MANIAPLANET_BUILD',	'2015-06-16_18_00');
+	define('MANIAPLANET_BUILD',	'2015-06-16_16_53');
 	define('API_VERSION',		'2013-04-16');
 	define('MIN_PHP_VERSION',	'5.2.1');
 


### PR DESCRIPTION
The MP Windows Dedicated Server as of 2015-06-16 has the build nr. 2015-06-16_16_53, in uaseco.php the build nr. of the linux server was the minimum requirement (2015-06-16_18_00)
